### PR TITLE
Erroneous Space in PhaseID NCTS5.1

### DIFF
--- a/conf/xsd/stypes.xsd
+++ b/conf/xsd/stypes.xsd
@@ -4194,7 +4194,7 @@
   <!--================================================================================-->
   <xs:simpleType name="phaseIDtype">
     <xs:restriction base="xs:token">
-      <xs:enumeration value=" NCTS5.1">
+      <xs:enumeration value="NCTS5.1">
         <xs:annotation>
           <xs:documentation>Phase NCTS 5.1</xs:documentation>
         </xs:annotation>


### PR DESCRIPTION
Space before NCTS5.1 which prevents 5.1 messages validating/deserializing.